### PR TITLE
Fix typo in tuple validation instructions

### DIFF
--- a/content/04-Arrays/03-Tuple-Validation/instructions.mdx
+++ b/content/04-Arrays/03-Tuple-Validation/instructions.mdx
@@ -23,7 +23,7 @@ each element of the `address` array have constraints of their own:
 - `number` should be an integer
 - `street_name` should be a string
 - `street_type` can have only one value from the list: `["Street", "Avenue", "Boulevard"]`
-- `direction` can have only one value from the list: `["NW", "NW", "SE", "SW"]`
+- `direction` can have only one value from the list: `["NW", "NE", "SE", "SW"]`
 
 ## Schema definition
 


### PR DESCRIPTION
NW was listed twice in the directions instead of NW and NE