### PR TITLE
Fix for ctrl+c on examples copies the whole text, not just the selection 

### DIFF
--- a/app/components/CodeSnippet/CodeSnippet.tsx
+++ b/app/components/CodeSnippet/CodeSnippet.tsx
@@ -38,13 +38,7 @@ export default function CodeSnippet({
   }
 
   return (
-    <div
-      className={styles.codeSnippetContainer}
-      onCopy={(e) => {
-        e.preventDefault();
-        e.clipboardData.setData("text/plain", children);
-      }}
-    >
+    <div className={styles.codeSnippetContainer}>
       <div
         className={styles.copyButton}
         onClick={() => {

--- a/app/components/CodeSnippet/CodeSnippet.tsx
+++ b/app/components/CodeSnippet/CodeSnippet.tsx
@@ -31,7 +31,6 @@ export default function CodeSnippet({
     return <span className={styles.inlineCode}>{children}</span>;
   }
   if (children[children.length - 1] === "\n") children = children.slice(0, -1);
-  // remove the last \n from children
 
   if (highlightLineStart && !highlightLineEnd) {
     highlightLineEnd = highlightLineStart;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "framer-motion": "^11.1.9",
     "geist": "^1.3.0",
     "gray-matter": "^4.0.3",
+    "my-app": "file:",
     "next": "^14.2.5",
     "next-mdx-remote": "^4.4.1",
     "prettier": "^3.3.3",


### PR DESCRIPTION
Code fix for ctrl+c on examples copies the whole text, not just the selection 
Closes #53
