### PR TITLE
fix: ctrl+c on examples copies the whole text

### DIFF
--- a/app/components/CodeSnippet/CodeSnippet.tsx
+++ b/app/components/CodeSnippet/CodeSnippet.tsx
@@ -2,9 +2,7 @@
 import SyntaxHighlighter from "react-syntax-highlighter";
 import {
   nightOwl,
-  atelierCaveLight,
   arduinoLight,
-  atelierEstuaryLight,
 } from "react-syntax-highlighter/dist/esm/styles/hljs";
 import styles from "./CodeSnippet.module.css";
 import { CSSProperties, useState } from "react";
@@ -38,13 +36,7 @@ export default function CodeSnippet({
   }
 
   return (
-    <div
-      className={styles.codeSnippetContainer}
-      onCopy={(e) => {
-        e.preventDefault();
-        e.clipboardData.setData("text/plain", children);
-      }}
-    >
+    <div className={styles.codeSnippetContainer}>
       <div
         className={styles.copyButton}
         onClick={() => {
@@ -71,9 +63,10 @@ export default function CodeSnippet({
         customStyle={{
           paddingInline: 0,
           paddingBlock: "10px",
+          whiteSpace: "pre", // This ensures code is not unnecessarily wrapped
         }}
-        wrapLines={true}
-        wrapLongLines={true}
+        wrapLines={false}  // Disable wrapping of lines
+        wrapLongLines={false}  // Prevent tokens from being wrapped
         lineNumberStyle={{
           color: "hsl(var(--text) / 0.6)",
           paddingRight: "12px",

--- a/app/components/CodeSnippet/CodeSnippet.tsx
+++ b/app/components/CodeSnippet/CodeSnippet.tsx
@@ -63,7 +63,6 @@ export default function CodeSnippet({
         customStyle={{
           paddingInline: 0,
           paddingBlock: "10px",
-          whiteSpace: "pre-wrap",
         }}
         wrapLines={true}
         wrapLongLines={false}

--- a/app/components/CodeSnippet/CodeSnippet.tsx
+++ b/app/components/CodeSnippet/CodeSnippet.tsx
@@ -75,7 +75,6 @@ export default function CodeSnippet({
         lineProps={(lineNumber) => {
           let style: CSSProperties = {
             display: "block",
-            width: "100%",
             paddingRight: "16px",
             paddingLeft: "4px",
             opacity: colorMode === "dark" ? 0.9 : 1,

--- a/app/components/CodeSnippet/CodeSnippet.tsx
+++ b/app/components/CodeSnippet/CodeSnippet.tsx
@@ -63,10 +63,10 @@ export default function CodeSnippet({
         customStyle={{
           paddingInline: 0,
           paddingBlock: "10px",
-          whiteSpace: "pre", // This ensures code is not unnecessarily wrapped
+          whiteSpace: "pre-wrap", // Keeps the original formatting while preventing overflow issues
         }}
-        wrapLines={false}  // Disable wrapping of lines
-        wrapLongLines={false}  // Prevent tokens from being wrapped
+        wrapLines={true}  // Allows line-level styling
+        wrapLongLines={false}  // Prevents individual words or tokens from wrapping unnecessarily
         lineNumberStyle={{
           color: "hsl(var(--text) / 0.6)",
           paddingRight: "12px",
@@ -78,6 +78,7 @@ export default function CodeSnippet({
             opacity: colorMode === "dark" ? 0.9 : 1,
             paddingRight: "16px",
             paddingLeft: "4px",
+            whiteSpace: "pre-wrap", 
           };
           if (
             highlightLineStart &&

--- a/app/components/CodeSnippet/CodeSnippet.tsx
+++ b/app/components/CodeSnippet/CodeSnippet.tsx
@@ -65,8 +65,8 @@ export default function CodeSnippet({
           paddingBlock: "10px",
           whiteSpace: "pre-wrap",
         }}
-        wrapLines={true}  
-        wrapLongLines={false}  
+        wrapLines={true}
+        wrapLongLines={false}
         lineNumberStyle={{
           color: "hsl(var(--text) / 0.6)",
           paddingRight: "12px",
@@ -75,11 +75,13 @@ export default function CodeSnippet({
         startingLineNumber={startingLineNumber}
         lineProps={(lineNumber) => {
           let style: CSSProperties = {
-            opacity: colorMode === "dark" ? 0.9 : 1,
+            display: "block",
+            width: "100%",
             paddingRight: "16px",
             paddingLeft: "4px",
-            whiteSpace: "pre-wrap", 
+            opacity: colorMode === "dark" ? 0.9 : 1,
           };
+
           if (
             highlightLineStart &&
             highlightLineEnd &&
@@ -95,6 +97,7 @@ export default function CodeSnippet({
               }`,
             };
           }
+
           return { style };
         }}
       >

--- a/app/components/CodeSnippet/CodeSnippet.tsx
+++ b/app/components/CodeSnippet/CodeSnippet.tsx
@@ -63,10 +63,10 @@ export default function CodeSnippet({
         customStyle={{
           paddingInline: 0,
           paddingBlock: "10px",
-          whiteSpace: "pre-wrap", // Keeps the original formatting while preventing overflow issues
+          whiteSpace: "pre-wrap",
         }}
-        wrapLines={true}  // Allows line-level styling
-        wrapLongLines={false}  // Prevents individual words or tokens from wrapping unnecessarily
+        wrapLines={true}  
+        wrapLongLines={false}  
         lineNumberStyle={{
           color: "hsl(var(--text) / 0.6)",
           paddingRight: "12px",


### PR DESCRIPTION
closes #53 