### PR TITLE
Changed UI to show toast when progress is reset

### DIFF
--- a/app/components/NavBarMenus/NavBarMenus.tsx
+++ b/app/components/NavBarMenus/NavBarMenus.tsx
@@ -45,7 +45,7 @@ export default function NavBarMenu() {
         <Popover
           placement="left"
           gutter={12}
-          onOpen={() =>  setIsOpen(true)}
+          onOpen={() => setIsOpen(true)}
           onClose={() => setIsOpen(false)}
           isOpen={isOpen}
         >
@@ -79,7 +79,7 @@ export default function NavBarMenu() {
                   toast({
                     title: "Progress Cleared",
                     description: "Your progress has been cleared",
-                    variant: "success",
+                    status: "success",
                     duration: 3000,
                     isClosable: true,
                   });

--- a/app/components/NavBarMenus/NavBarMenus.tsx
+++ b/app/components/NavBarMenus/NavBarMenus.tsx
@@ -16,6 +16,7 @@ import {
   PopoverHeader,
   PopoverTrigger,
   useColorMode,
+  useToast,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import navBarStyles from "../NavBar/NavBar.module.css";
@@ -24,7 +25,9 @@ import { sendGAEvent } from "@next/third-parties/google";
 export default function NavBarMenu() {
   const { colorMode } = useColorMode();
 
-  const [isCleared, setIsCleared] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toast = useToast();
 
   return (
     <Menu closeOnSelect={false} gutter={4}>
@@ -42,7 +45,9 @@ export default function NavBarMenu() {
         <Popover
           placement="left"
           gutter={12}
-          onOpen={() => setIsCleared(false)}
+          onOpen={() =>  setIsOpen(true)}
+          onClose={() => setIsOpen(false)}
+          isOpen={isOpen}
         >
           <PopoverTrigger>
             <MenuItem display={"flex"} gap={"8px"} color={"hsl(var(--error))"}>
@@ -61,23 +66,26 @@ export default function NavBarMenu() {
             <PopoverCloseButton />
             <PopoverHeader>Confirmation!</PopoverHeader>
             <PopoverBody>
-              {isCleared
-                ? "Your Progress is cleared"
-                : "Are you sure you want to reset your progress?"}
+              Are you sure you want to reset your progress?
               <Button
-                colorScheme={isCleared ? "green" : "red"}
-                backgroundColor={
-                  isCleared ? "hsl(var(--success))" : "hsl(var(--error))"
-                }
+                colorScheme="red"
+                backgroundColor="hsl(var(--error))"
                 size="sm"
                 width={"100%"}
                 mt={2}
                 onClick={() => {
                   localStorage.removeItem("progress");
-                  setIsCleared(true);
+                  setIsOpen(false);
+                  toast({
+                    title: "Progress Cleared",
+                    description: "Your progress has been cleared",
+                    variant: "success",
+                    duration: 3000,
+                    isClosable: true,
+                  });
                 }}
               >
-                {isCleared ? "Done!" : "RESET"}
+                RESET
               </Button>
             </PopoverBody>
           </PopoverContent>

--- a/app/styles/theme.ts
+++ b/app/styles/theme.ts
@@ -142,10 +142,10 @@ const Alert = {
       container: {
         bg: "hsl(var(--success) / 0.6)",
         color: "hsl(var(--text) / 0.8)",
-      }
+      },
     },
-  }
-}
+  },
+};
 
 export const theme = extendTheme({
   config: {

--- a/app/styles/theme.ts
+++ b/app/styles/theme.ts
@@ -136,17 +136,6 @@ const Popover = {
   },
 };
 
-const Alert = {
-  variants: {
-    success: {
-      container: {
-        bg: "hsl(var(--success) / 0.6)",
-        color: "hsl(var(--text) / 0.8)",
-      },
-    },
-  },
-};
-
 export const theme = extendTheme({
   config: {
     initialColorMode: "light",
@@ -160,6 +149,6 @@ export const theme = extendTheme({
       },
     },
   },
-  components: { Button, Menu, Switch, Drawer, Tooltip, Popover, Alert },
+  components: { Button, Menu, Switch, Drawer, Tooltip, Popover },
   fonts: {},
 });

--- a/app/styles/theme.ts
+++ b/app/styles/theme.ts
@@ -136,6 +136,17 @@ const Popover = {
   },
 };
 
+const Alert = {
+  variants: {
+    success: {
+      container: {
+        bg: "hsl(var(--success) / 0.6)",
+        color: "hsl(var(--text) / 0.8)",
+      }
+    },
+  }
+}
+
 export const theme = extendTheme({
   config: {
     initialColorMode: "light",
@@ -149,6 +160,6 @@ export const theme = extendTheme({
       },
     },
   },
-  components: { Button, Menu, Switch, Drawer, Tooltip, Popover },
+  components: { Button, Menu, Switch, Drawer, Tooltip, Popover, Alert },
   fonts: {},
 });


### PR DESCRIPTION
I changed the verbiage on  isCleared to isOpen to signify the model status.  I stayed in line with the current theme on the project. 

![Screenshot_20241003_110741](https://github.com/user-attachments/assets/d40fedbe-75fe-4bb5-835a-4b648acbe54b)
![Screenshot_20241003_110800](https://github.com/user-attachments/assets/008db4f8-c647-49f9-b2ac-7cea1860d7bf)
