### PR TITLE
02-02 Regular Expression in Strings Fixed Mistake {10}, Added Test, and Hint

### DIFF
--- a/content/02-Primitive-Types/02-Regular-Expressions-in-Strings/code.ts
+++ b/content/02-Primitive-Types/02-Regular-Expressions-in-Strings/code.ts
@@ -57,6 +57,16 @@ const testCases = [
   {
     input: {
       name: "John Doe",
+      age: 30,
+      postalCode: "123456",
+      phoneNumber: "12345678901",
+      countryCode: "IN",
+    },
+    expected: true,
+  },
+  {
+    input: {
+      name: "John Doe",
       age: "30",
       postalCode: "123456",
       phoneNumber: "1234567890",
@@ -139,7 +149,7 @@ const testCases = [
 const solution = structuredClone(code);
 solution.properties.phoneNumber = {
   type: "string",
-  pattern: "^[0-9]{10}$",
+  pattern: "^[0-9]{10,}$",
 };
 
 solution.properties.postalCode = {

--- a/content/02-Primitive-Types/02-Regular-Expressions-in-Strings/instructions.mdx
+++ b/content/02-Primitive-Types/02-Regular-Expressions-in-Strings/instructions.mdx
@@ -50,6 +50,7 @@ Now, try to modify the `postalCode`, `phoneNumber` and `countryCode` fields in t
 - The `phoneNumber` should be a string with a **minimum length of 10** characters and should **contain only digits**.
 -  The `countryCode` should be a string with a **length of exactly 2** characters and should **contain only uppercase letters**. 
 
-> **Hint:** to only allow uppercase letters, you can use the regular expression `[A-Z]` in your regex pattern.
-
-> **Hint**: Use {n,} to specify that a pattern should match at least n times. To restrict the number of matches between a minimum and maximum, use {n,m} for a range of n to m times.
+> **Hints:** 
+> - To only allow uppercase letters, you can use the regular expression `[A-Z]` in your regex pattern.
+> - Use `{n}` to specify that a pattern should match exactly n times.
+> - Use `{n,}` to specify that a pattern should match at least n times. To restrict the number of matches between a minimum and maximum, you can use `{n,m}` for a range of n to m times.

--- a/content/02-Primitive-Types/02-Regular-Expressions-in-Strings/instructions.mdx
+++ b/content/02-Primitive-Types/02-Regular-Expressions-in-Strings/instructions.mdx
@@ -51,3 +51,5 @@ Now, try to modify the `postalCode`, `phoneNumber` and `countryCode` fields in t
 -  The `countryCode` should be a string with a **length of exactly 2** characters and should **contain only uppercase letters**. 
 
 > **Hint:** to only allow uppercase letters, you can use the regular expression `[A-Z]` in your regex pattern.
+
+> **Hint**: Use {n,} to specify that a pattern should match at least n times. To restrict the number of matches between a minimum and maximum, use {n,m} for a range of n to m times.


### PR DESCRIPTION
02-02 Regular Expression in Strings: The pattern {10} was matching exactly 10 occurrences instead of 10 or more  (minimum length of 10). I added the correct solution, {10,}, which matches 10 or more occurrences. A test was added with 11 numbers that would fail with {10} and pass with {10,}. I also added a hint to the instructions.

