### PR TITLE
 Use $ref instead of allOf for Extending Closed Schemas #65 

### DIFF
--- a/content/07-Miscellaneous/01-Extending-Closed-Schemas-with-unevaluatedProperties/code.ts
+++ b/content/07-Miscellaneous/01-Extending-Closed-Schemas-with-unevaluatedProperties/code.ts
@@ -1,22 +1,18 @@
 const code: any = {
-  allOf: [
-    {
-      type: "object",
-      properties: {
-        street_address: { type: "string" },
-        city: { type: "string" },
-        state: { type: "string" },
-      },
-      required: ["street_address", "city", "state"],
-    },
-  ],
+  $ref: "https://example.com/address",
   properties: {
+    street_address: { type: "string" },
+    city: { type: "string" },
+    state: { type: "string" },
     type: { enum: ["residential", "business"] },
   },
-  required: ["type"],
+  required: ["street_address", "city", "state", "type"],
+  additionalProperties: false
 };
 
 let solution = structuredClone(code);
+
+
 solution.unevaluatedProperties = {
   type: "number",
 };
@@ -39,7 +35,7 @@ const testCases = [
       type: "business",
       zip: 20500,
     },
-    expected: true,
+    expected: true, 
   },
   {
     input: {
@@ -47,9 +43,9 @@ const testCases = [
       city: "Washington",
       state: "DC",
       type: "business",
-      zip: "20500",
+      zip: "20500", 
     },
-    expected: false,
+    expected: false, 
   },
   {
     input: {
@@ -57,7 +53,7 @@ const testCases = [
       city: "Washington",
       state: "DC",
       type: "business",
-      zip: null,
+      zip: null, 
     },
     expected: false,
   },

--- a/content/07-Miscellaneous/01-Extending-Closed-Schemas-with-unevaluatedProperties/instructions.mdx
+++ b/content/07-Miscellaneous/01-Extending-Closed-Schemas-with-unevaluatedProperties/instructions.mdx
@@ -1,64 +1,21 @@
 ---
 title: Extending Closed Schemas with unevaluatedProperties
 description: Extending Closed Schemas in JSON Schema Objects using the unevaluatedProperties keyword
-keywords:  extending closed schemas,unevaluatedProperties , JSON Schema, JSON Schema objects
+keywords: extending closed schemas, unevaluatedProperties, JSON Schema, JSON Schema objects
 ---
-
 
 # Extending Closed Schemas
 
-Previously in the Objects module, we learned to `additionalProperties`. However, it is important to note that `additionalProperties` only recognizes properties declared in the same [subschema](https://json-schema.org/learn/glossary#subschema) as itself. 
+Previously in the Objects module, we learned about `additionalProperties`. However, it is important to note that `additionalProperties` only recognizes properties declared in the same [subschema](https://json-schema.org/learn/glossary#subschema) as itself.
 
-So, `additionalProperties` can restrict you from "extending" a schema using combining [keywords](https://json-schema.org/learn/glossary#subschema) such as `allOf`. In the following example, we can see how the `additionalProperties` can cause attempts to extend the address schema example to fail. 
+This limitation can restrict you from "extending" a schema using combining [keywords](https://json-schema.org/learn/glossary#subschema) such as `$ref`. In the following example, we use `$ref` to extend the address schema (`https://example.com/address`) by adding a `type` property while controlling additional properties. This approach showcases how `unevaluatedProperties` resolves the challenges of extending schemas.
 
-```json highlightLineStart={11}
+```json highlightLineStart={6,13,16}
 {
-  "allOf": [
-    {
-      "type": "object",
-      "properties": {
-        "street_address": { "type": "string" },
-        "city": { "type": "string" },
-        "state": { "type": "string" }
-      },
-      "required": ["street_address", "city", "state"],
-      "additionalProperties": false
-    }
-  ],
+  "$ref": "https://example.com/address",
   "properties": {
     "type": { "enum": [ "residential", "business" ] }
   },
-  "required": ["type"]
+  "required": ["type"],
+  "unevaluatedProperties": false
 }
-```
-The above [schema](https://json-schema.org/learn/glossary#schema) will not allow you to define `type` property. because `additionalProperties` is set to `false`. The reason is, `additionalProperties` only recognizes properties declared in the same [subschema](https://json-schema.org/learn/glossary#subschema). 
-
-
-## Unevaluated Properties
-
-The challenge we saw with `additionalProperties` can be solved using the `unevaluatedProperties` keyword. This keyword allows you to define properties that are not evaluated by the current schema. 
-
-```json highlightLineStart={15}
-{
-  "allOf": [
-    {
-      "type": "object",
-      "properties": {
-        "street_address": { "type": "string" },
-        "city": { "type": "string" },
-        "state": { "type": "string" }
-      },
-      "required": ["street_address", "city", "state"],    }
-  ],
-  "properties": {
-    "type": { "enum": [ "residential", "business" ] }
-  },
-  "unevaluatedProperties": false,
-  "required": ["type"]
-}
-```
-
-## Task 
-
-You are give the same schema in the <SideEditorLink/>. Add `unevaluatedProperties` to the schema to allow the only `number` as an additional property. 
-

--- a/content/07-Miscellaneous/01-Extending-Closed-Schemas-with-unevaluatedProperties/instructions.mdx
+++ b/content/07-Miscellaneous/01-Extending-Closed-Schemas-with-unevaluatedProperties/instructions.mdx
@@ -8,14 +8,52 @@ keywords: extending closed schemas, unevaluatedProperties, JSON Schema, JSON Sch
 
 Previously in the Objects module, we learned about `additionalProperties`. However, it is important to note that `additionalProperties` only recognizes properties declared in the same [subschema](https://json-schema.org/learn/glossary#subschema) as itself.
 
-This limitation can restrict you from "extending" a schema using combining [keywords](https://json-schema.org/learn/glossary#subschema) such as `$ref`. In the following example, we use `$ref` to extend the address schema (`https://example.com/address`) by adding a `type` property while controlling additional properties. This approach showcases how `unevaluatedProperties` resolves the challenges of extending schemas.
+So, `additionalProperties` can restrict you from "extending" a schema using combining [keywords](https://json-schema.org/learn/glossary#subschema) such as `$ref`. In the following example, we can see how the `additionalProperties` can cause attempts to extend the address schema example to fail.
 
-```json highlightLineStart={6,13,16}
+```json highlightLineStart={11}
+{
+  "type": "object",
+  "properties": {
+    "street_address": { "type": "string" },
+    "city": { "type": "string" },
+    "state": { "type": "string" }
+  },
+  "required": ["street_address", "city", "state"],
+  "additionalProperties": false
+}
+
+```
+
+The above [schema](https://json-schema.org/learn/glossary#schema) will not allow you to define the `type` property because `additionalProperties` is set to `false`. The reason is, `additionalProperties` only recognizes properties declared in the same [subschema](https://json-schema.org/learn/glossary#subschema).
+
+## Unevaluated Properties
+
+The challenge we saw with `additionalProperties` can be solved using the `unevaluatedProperties` keyword. This keyword allows you to define properties that are not evaluated by the current schema.
+
+```json highlightLineStart={15}
 {
   "$ref": "https://example.com/address",
   "properties": {
     "type": { "enum": [ "residential", "business" ] }
   },
+  "unevaluatedProperties": { "type": "number" },
   "required": ["type"],
-  "unevaluatedProperties": false
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street_address": { "type": "string" },
+        "city": { "type": "string" },
+        "state": { "type": "string" }
+      },
+      "required": ["street_address", "city", "state"]
+    }
+  }
 }
+```
+
+## Task
+
+You are given the same schema in the <SideEditorLink/>. Add `unevaluatedProperties` to the schema to allow only `number` as an additional property.
+
+---

--- a/content/07-Miscellaneous/01-Extending-Closed-Schemas-with-unevaluatedProperties/instructions.mdx
+++ b/content/07-Miscellaneous/01-Extending-Closed-Schemas-with-unevaluatedProperties/instructions.mdx
@@ -12,15 +12,25 @@ So, `additionalProperties` can restrict you from "extending" a schema using comb
 
 ```json highlightLineStart={11}
 {
-  "type": "object",
+  "$ref": "https://example.com/address",
   "properties": {
-    "street_address": { "type": "string" },
-    "city": { "type": "string" },
-    "state": { "type": "string" }
+    "type": { "enum": ["residential", "business"] }
   },
-  "required": ["street_address", "city", "state"],
-  "additionalProperties": false
+  "required": ["type"],
+  "additionalProperties": false,
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street_address": { "type": "string" },
+        "city": { "type": "string" },
+        "state": { "type": "string" }
+      },
+      "required": ["street_address", "city", "state"]
+    }
+  }
 }
+
 
 ```
 


### PR DESCRIPTION
This pull request updates the instructions.mdx file to use $ref instead of allOf for extending closed schemas. The changes include:

Explanation of the limitations of additionalProperties.
Demonstration of how to use $ref to extend the address schema by adding a type property.
Use of unevaluatedProperties to control additional properties.
Changes
Updated instructions.mdx to reflect the correct usage of $ref and unevaluatedProperties.
Related Issue
Fixes #65: Use $ref instead of allOf for Extending Closed Schemas