### PR TITLE
[FEAT] : Added Adjustable Vertical Seperator between Editor and ContentViewer

### DIFF
--- a/app/components/ContentViewer/ContentViewer.module.css
+++ b/app/components/ContentViewer/ContentViewer.module.css
@@ -1,20 +1,18 @@
 .content {
   display: flex;
   flex-direction: column;
-
   overflow-y: auto;
   flex: 1;
-  padding-right: 14px;
-  padding-bottom: 12px;
-  padding-left: 14px;
+  padding: 14px;
+  height: 100%;
+  width: 100%;
 }
+
 .contentWrapper {
   border-right: 1px solid hsl(var(--border-color));
-
   display: flex;
   flex-direction: column;
-
   height: 100%;
-  flex: 1;
-  height: 100%;
+  width: 100%;
+  overflow: hidden;
 }

--- a/app/components/EditorNOutput/EditorNOutput.module.css
+++ b/app/components/EditorNOutput/EditorNOutput.module.css
@@ -3,14 +3,12 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-
-  max-width: 50%;
+  width: 100%;
+  overflow: hidden;
 }
 
 .outputWrapper {
   width: 100%;
-
-  /* padding: 16px; */
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -19,11 +17,13 @@
   border-left: none;
   height: 100%;
 }
+
 .divider {
   width: 100%;
   height: 6px;
   background-color: hsl(var(--border-color));
   cursor: row-resize;
+  flex-shrink: 0;
 }
 
 .divider:hover,

--- a/app/components/ResizableContent.tsx
+++ b/app/components/ResizableContent.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import styles from "@/app/content/[...markdownPath]/page.module.css";
+import ContentViewer from "./ContentViewer";
+import EditorNOutput from "./EditorNOutput";
+
+interface ResizableContentProps {
+  content: React.ReactNode;
+  codeFile: any;
+  nextStepPath: string | undefined;
+  stepIndex: number;
+  chapterIndex: number;
+}
+
+export default function ResizableContent({
+  content,
+  codeFile,
+  nextStepPath,
+  stepIndex,
+  chapterIndex,
+}: ResizableContentProps) {
+  const [leftWidth, setLeftWidth] = useState(600);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDraggingRef = useRef<boolean>(false);
+
+  const handleMouseDown = () => {
+    isDraggingRef.current = true;
+  };
+
+  const handleMouseUp = () => {
+    isDraggingRef.current = false;
+  };
+
+  const handleMouseMove = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent> | MouseEvent,
+  ) => {
+    if (!isDraggingRef.current) return;
+
+    const containerRect = containerRef.current!.getBoundingClientRect();
+    const newLeftWidth = e.clientX - containerRect.left;
+
+    const minWidth = 300;
+    const maxWidth = containerRect.width * 0.7;
+
+    if (newLeftWidth >= minWidth && newLeftWidth <= maxWidth) {
+      setLeftWidth(newLeftWidth);
+      localStorage.setItem("horizontalLeftWidth", String(newLeftWidth));
+    }
+  };
+
+  useEffect(() => {
+    const savedWidth = localStorage.getItem("horizontalLeftWidth");
+    if (savedWidth) {
+      setLeftWidth(Number(savedWidth));
+    }
+  }, []);
+
+  return (
+    <div
+      className={styles.mainArea}
+      ref={containerRef}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+    >
+      <div className={styles.leftPane} style={{ width: `${leftWidth}px` }}>
+        <ContentViewer>{content}</ContentViewer>
+      </div>
+      <div className={styles.divider} onMouseDown={handleMouseDown} />
+      <div className={styles.rightPane}>
+        <EditorNOutput
+          codeFile={codeFile}
+          nextStepPath={nextStepPath}
+          stepIndex={stepIndex}
+          chapterIndex={chapterIndex}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/content/[...markdownPath]/page.module.css
+++ b/app/content/[...markdownPath]/page.module.css
@@ -1,7 +1,41 @@
 .mainArea {
   display: flex;
   flex-direction: row;
-  flex: 12;
+  height: calc(100vh - 60px);
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.leftPane {
   height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
+  min-width: 300px;
+  max-width: 70%;
+  display: flex;
+}
+
+.rightPane {
+  flex: 1;
+  height: 100%;
+  min-width: 300px;
+  overflow: hidden;
+  display: flex;
+}
+
+.divider {
+  width: 4px;
+  height: 100%;
+  background-color: hsl(var(--border-color));
+  cursor: col-resize;
+  transition: background-color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.divider:hover {
+  background-color: hsl(var(--primary) / 0.75);
+}
+
+.divider:active {
+  background-color: hsl(var(--primary) / 0.75);
 }

--- a/app/content/[...markdownPath]/page.tsx
+++ b/app/content/[...markdownPath]/page.tsx
@@ -1,9 +1,7 @@
 import { contentManager } from "@/lib/contentManager";
-import styles from "./page.module.css";
 import React from "react";
 import { parseLessonFolder } from "@/lib/server-functions";
-import ContentViewer from "@/app/components/ContentViewer";
-import EditorNOutput from "@/app/components/EditorNOutput";
+import ResizableContent from "@/app/components/ResizableContent";
 
 export function generateMetadata({
   params,
@@ -38,28 +36,28 @@ export default async function Content({
     contentManager.getPageMeta(urlPath);
   const { Page, metadata, codeFile } = parseLessonFolder(mdPath, codePath);
 
+  const pageContent = <Page />;
+
   return (
-    <div className={styles.mainArea}>
-      <ContentViewer>
-        <Page />
-      </ContentViewer>
-      <EditorNOutput
-        codeFile={codeFile}
-        nextStepPath={nextStepPath}
-        stepIndex={stepIndex}
-        chapterIndex={chapterIndex}
-      />
-    </div>
+    <ResizableContent
+      content={pageContent}
+      codeFile={codeFile}
+      nextStepPath={nextStepPath}
+      stepIndex={stepIndex}
+      chapterIndex={chapterIndex}
+    />
   );
 }
+
 export async function generateStaticParams() {
   const outline = contentManager.getOutline();
   const pathList: { markdownPath: string[] }[] = [];
 
   outline.map((item) => {
     item.steps.map((step) => {
+      const pathSegments = step.fullPath.split("/");
       pathList.push({
-        markdownPath: [item.folderName, step.fileName],
+        markdownPath: pathSegments,
       });
     });
   });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- Feature: Added a resizable vertical separator between content viewer and editor

**Issue Number:**
- Closes : #130 
**Screenshots/videos:**
![image](https://github.com/user-attachments/assets/92e5893d-f5b2-4f4d-a710-28cbe5969990)

**If relevant, did you update the documentation?**
- No documentation updates required as this is a UI enhancement

**Summary**
This PR introduces a resizable vertical separator between the content viewer and editor panels, improving the user experience by allowing users to adjust the width of each panel according to their preferences. The separator features:

- A 4px wide draggable divider
- Visual feedback on hover and active states using the primary theme color
- Smooth transition animations
- Minimum width constraints (300px) for both panels to ensure usability
- Maximum width constraint (70%) for the left panel to maintain layout balance

The implementation uses CSS flexbox for layout management and includes proper cursor styling to indicate the resizable nature of the divider.

**Does this PR introduce a breaking change?**
No, this is a non-breaking change that enhances the existing UI without affecting any functionality or existing features.

**Technical Details:**
- Added new CSS module styles in `page.module.css`
- Implemented flexbox-based layout for the main area
- Added hover and active states for the divider using the primary theme color
- Set appropriate min/max width constraints for both panels