### PR TITLE
feat: Display passing test cases for valid schemas 

### DIFF
--- a/app/components/NavBarMenus/NavBarMenus.tsx
+++ b/app/components/NavBarMenus/NavBarMenus.tsx
@@ -38,7 +38,6 @@ export default function NavBarMenu() {
         className={navBarStyles.menuButton}
         onBlur={() => setIsOpen(false)}
         onClick={() => {
-          
           sendGAEvent("event", "buttonClicked", {
             value: "Settings",
           });

--- a/app/components/Output/Output.tsx
+++ b/app/components/Output/Output.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import styles from "./Output.module.css";
 import classnames from "classnames";
 import { OutputResult } from "@/lib/types";
-import FailedTestCasesWindow from "../TestCaseWindow/TestCaseWindow";
+import TestCasesWindow from "../TestCaseWindow/TestCaseWindow";
 import MyBtn from "../MyBtn";
 import { InvalidSchemaError } from "@hyperjump/json-schema/draft-2020-12";
 import { schemaUrl } from "@/lib/validators";
@@ -101,12 +101,18 @@ function Output({
     );
   } else if (outputResult.validityStatus == "valid") {
     outputBodyContent = (
-      <div className={styles.valid}>
-        <b className={styles.validMessage}>Valid Schema!</b>
-        <span className={styles.validSmallMessage}>
-          Let&apos;s move on to the next step
-        </span>
-      </div>
+      <>
+        <div className={styles.valid}>
+          <b className={styles.validMessage}>Valid Schema!</b>
+          <span className={styles.validSmallMessage}>
+            Let&apos;s move on to the next step
+          </span>
+        </div>
+        <TestCasesWindow
+          testCaseResult={outputResult.testCaseResults!}
+          totalTestCases={outputResult.totalTestCases!}
+        />
+      </>
     );
   } else if (outputResult.validityStatus == "syntaxError") {
     outputBodyContent = (
@@ -128,7 +134,7 @@ function Output({
     );
   } else {
     outputBodyContent = (
-      <FailedTestCasesWindow
+      <TestCasesWindow
         testCaseResult={outputResult.testCaseResults!}
         totalTestCases={outputResult.totalTestCases!}
       />

--- a/app/components/TestCaseWindow/TestCaseWindow.tsx
+++ b/app/components/TestCaseWindow/TestCaseWindow.tsx
@@ -110,12 +110,14 @@ export default function TestCasesWindow({
 
   return (
     <div className={styles.TestCasesWindow}>
-      <div className={styles.TestCasesHeaderWrapper}>
-        <span className={styles.TestCasesHeader}>Invalid Schema!</span>
-        <span className={styles.TestCasesSubtitle}>
-          {numberOfFailedTestCases} out of {totalTestCases} test cases failed
-        </span>
-      </div>
+      {numberOfFailedTestCases > 0 && (
+        <div className={styles.TestCasesHeaderWrapper}>
+          <span className={styles.TestCasesHeader}>Invalid Schema!</span>
+          <span className={styles.TestCasesSubtitle}>
+            {numberOfFailedTestCases} out of {totalTestCases} test cases failed
+          </span>
+        </div>
+      )}
       <Flex dir="row" gap={2}>
         {!areBothDisabled && (
           <button

--- a/lib/client-functions.ts
+++ b/lib/client-functions.ts
@@ -58,7 +58,16 @@ export async function validateCode(
     }
 
     if (validationStatus === "valid") {
-      dispatchOutput({ type: "valid", payload: {} });
+      const sortedResults = testCaseResults.sort((a, b) => {
+        if (a.passed === b.passed) {
+          return 0; // If both are the same, their order doesn't change
+        }
+        return a.passed ? 1 : -1; // If a.passed is true, put a after b; if false, put a before b
+      });
+      dispatchOutput({
+        type: "valid",
+        payload: { testCaseResults: sortedResults, totalTestCases },
+      });
       completeStep(chapterIndex, stepIndex);
       sendGAEvent("event", "validation", {
         validation_result: "passed",

--- a/lib/reducers.ts
+++ b/lib/reducers.ts
@@ -16,7 +16,12 @@ export function outputReducer(
 ): OutputResult {
   switch (action.type) {
     case "valid":
-      return { ...state, validityStatus: "valid" };
+      return {
+        ...state,
+        validityStatus: "valid",
+        testCaseResults: action.payload.testCaseResults,
+        totalTestCases: action.payload.totalTestCases,
+      };
     case "syntaxError":
       return {
         ...state,


### PR DESCRIPTION
# Feat: Display Passing Test Cases for Valid Schemas

## What kind of change does this PR introduce?

- Feature  
- Refactoring

## Issue Number

Closes #69

## Screenshots/videos

**Screenshot of the updated output view showing the list of passed test cases:**

> 
<img width="941" height="893" alt="Screenshot 2025-07-21 142941" src="https://github.com/user-attachments/assets/5c417c7a-d279-448f-b64a-dd7e4d6ff538" />



## If relevant, did you update the documentation?

N/A

---

## Summary

This change enhances the user feedback mechanism by displaying all passing test cases when a user's schema is successfully validated.

Previously, a correct submission only showed a generic `"Valid Schema!"` message, hiding the details of the tests that were run. This update ensures that users can see a detailed breakdown of all the test cases they passed, providing better positive reinforcement and a more complete learning experience.

---

## Summary of Changes

- **`client-function.ts`**  
  Modified `validateCode()` to pass the `testCaseResults` to the reducer on successful validation, instead of discarding them.

- **`reducers.ts`**  
  Updated the `outputReducer` to correctly store the successful test results in the application state.

- **`Output.tsx`**  
  Adjusted the `Output` component to render the `TestCasesWindow` for valid schemas, displaying the list of all passed tests below the success message.

- **`TestCaseWindow.tsx`**
  - Made the `"Invalid Schema!"` header conditional, so it only appears if there are actual failed tests.
  - Renamed the component from `FailedTestCasesWindow` to `TestCasesWindow` to better reflect its new role.

---

## Does this PR introduce a breaking change?

No — this PR updates the output view to show passing test cases.  
It also applies automated formatting and lint fixes to the entire codebase.

---

<!--
In order to keep off-topic discussion to a minimum, it helps if the "work to be done" is already agreed on.
Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR.
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->
