### PR TITLE
Update format keyword reference link in instructions

### DIFF
--- a/content/06-Combining-Subschemas/04-Valid-Against-oneOf-the-Subschemas(XOR)/instructions.mdx
+++ b/content/06-Combining-Subschemas/04-Valid-Against-oneOf-the-Subschemas(XOR)/instructions.mdx
@@ -52,7 +52,7 @@ We will combine using `oneOf` and `required`, to ensure that only one of the pro
 }
 ```
 
-> Notice the `format` keyword with `date` used in the `dateOfBirth` property. By default, `format` is just an annotation and **does not effect validation**. you can learn more about the format keyword [here](https://tour.json-schema.org/content/08-Annotating-JSON-Schemas/04-format-and-examples).
+> Notice the `format` keyword with `date` used in the `dateOfBirth` property. By default, `format` is just an annotation and **does not effect validation**. you can learn more about the format keyword [here](https://json-schema.org/understanding-json-schema/reference/type#format).
 
 ## Task
 


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bugfix — corrected an invalid link reference in the documentation.

**Issue Number:**
- Closes #186  <!-- Replace <issue-number> with the actual issue number -->

**Screenshots/videos:**

N/A

**If relevant, did you update the documentation?**

No

**Summary**

This PR fixes a broken link in the documentation where the original URL pointed to a non-existent section (`There is no 'format' section in the target location.`).  
The correct link is now updated to:

🔗 https://json-schema.org/understanding-json-schema/reference/type#format

**Does this PR introduce a breaking change?**

No breaking changes.
