### PR TITLE
Fix broken link issue 186

### DIFF
--- a/content/06-Combining-Subschemas/04-Valid-Against-oneOf-the-Subschemas(XOR)/instructions.mdx
+++ b/content/06-Combining-Subschemas/04-Valid-Against-oneOf-the-Subschemas(XOR)/instructions.mdx
@@ -52,7 +52,7 @@ We will combine using `oneOf` and `required`, to ensure that only one of the pro
 }
 ```
 
-> Notice the `format` keyword with `date` used in the `dateOfBirth` property. By default, `format` is just an annotation and **does not effect validation**. you can learn more about the format keyword [here](https://json-schema.org/understanding-json-schema/reference/string#format).
+> Notice the `format` keyword with `date` used in the `dateOfBirth` property. By default, `format` is just an annotation and **does not effect validation**. you can learn more about the format keyword [here](https://tour.json-schema.org/content/08-Annotating-JSON-Schemas/04-format-and-examples).
 
 ## Task
 

--- a/content/06-Combining-Subschemas/04-Valid-Against-oneOf-the-Subschemas(XOR)/instructions.mdx
+++ b/content/06-Combining-Subschemas/04-Valid-Against-oneOf-the-Subschemas(XOR)/instructions.mdx
@@ -52,7 +52,7 @@ We will combine using `oneOf` and `required`, to ensure that only one of the pro
 }
 ```
 
-> Notice the `format` keyword with `date` used in the `dateOfBirth` property. By default, `format` is just an annotation and **does not effect validation**. you can learn more about the format keyword [here](https://tour.json-schema.org/content/08-Annotating-JSON-Schemas/04-format-and-examples).
+> Notice the `format` keyword with `date` used in the `dateOfBirth` property. By default, `format` is just an annotation and **does not affect validation**. you can learn more about the format keyword [here](https://tour.json-schema.org/content/08-Annotating-JSON-Schemas/04-format-and-examples).
 
 ## Task
 
@@ -66,6 +66,6 @@ We will combine using `oneOf` and `required`, to ensure that only one of the pro
 You are given a [schema](https://json-schema.org/learn/glossary#schema) for the above JSON document in the <SideEditorLink/>. Using `oneOf` keyword, update schema to ensure that the `age` follows one of the below conditions:
 
 - Either between 18 and 60 (inclusive) or,
-- Greater then 65 (inclusive).
+- Greater than 65 (inclusive).
 
 > **Hint:** use `minimum` and `maximum` keywords to define the range.

--- a/content/06-Combining-Subschemas/06-inverting-validation-with-not/instructions.mdx
+++ b/content/06-Combining-Subschemas/06-inverting-validation-with-not/instructions.mdx
@@ -17,7 +17,7 @@ keywords: "not keyword, JSON Schema, conditional validation, properties, instanc
 }
 ```
 
-We want the `age` to be greater then or equal to 18. but it should not be 21. We can use `not` keyword to define this condition.
+We want the `age` to be greater than or equal to 18. but it should not be 21. We can use `not` keyword to define this condition.
 
 
 ```json highlightLineStart={8} 


### PR DESCRIPTION
✅ Pull Request: Fix broken link to format keyword documentation

What kind of change does this PR introduce?

🛠️ Bug fix

Issue Number

Closes #186

📸 Screenshots / Videos

N/A (link fix only)

📄 Summary

This PR fixes a broken documentation link related to the format keyword.

Updated link from:
https://json-schema.org/understanding-json-schema/

To the correct page on docs site:
https://json-schema.org/learn/getting-started-step-by-step/08-Annotating-JSON-Schemas/04-format-and-examples

This prevents users from getting redirected to the wrong or missing reference.