### PR TITLE
feat: Implement search functionality for chapters and lessons

### DIFF
--- a/app/components/OutlineDrawer/OutlineDrawer.module.css
+++ b/app/components/OutlineDrawer/OutlineDrawer.module.css
@@ -2,3 +2,24 @@
   display: flex;
   flex-direction: column;
 }
+
+/* 
+  No results message styling
+  Displayed when search query returns no matching chapters or lessons
+*/
+.noResults {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--chakra-colors-gray-500);
+}
+
+.noResults p:first-child {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+}
+
+.noResults p:last-child {
+  font-size: 0.875rem;
+  opacity: 0.8;
+}

--- a/app/utils/hooks.ts
+++ b/app/utils/hooks.ts
@@ -1,0 +1,47 @@
+import { useState, useMemo } from "react";
+import { ContentOutline, Chapter } from "@/lib/types";
+
+/**
+ * Hook to search chapters and lessons by title
+ * Returns filtered outline based on search query
+ */
+export function useSearch(outline: ContentOutline) {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Filter outline based on search query (memoized for performance)
+  const filteredOutline = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return outline;
+    }
+
+    const query = searchQuery.toLowerCase().trim();
+
+    // Filter chapters and steps by search query
+    const filtered = outline
+      .map((chapter) => {
+        const chapterMatches = chapter.title.toLowerCase().includes(query);
+        const matchingSteps = chapter.steps.filter((step) =>
+          step.title.toLowerCase().includes(query)
+        );
+
+        // Include chapter if title or any step matches
+        if (chapterMatches || matchingSteps.length > 0) {
+          return {
+            ...chapter,
+            steps: chapterMatches ? chapter.steps : matchingSteps,
+          };
+        }
+
+        return null;
+      })
+      .filter((chapter): chapter is Chapter => chapter !== null);
+
+    return filtered;
+  }, [searchQuery, outline]);
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    filteredOutline,
+  };
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature - Added search functionality to the tour outline

**Issue Number:**

- Closes #164

**Screenshots/videos:**

<!-- Add a screenshot or short video showing the search feature in action - search input in the outline drawer and filtered results -->

https://github.com/user-attachments/assets/c89f2f61-a55b-43b7-9179-aa279a0f8867



**If relevant, did you update the documentation?**

N/A - No documentation updates needed for this UI feature

**Summary**

This PR implements a search feature in the outline drawer that allows users to quickly find chapters and lessons by title. The search:
- Filters chapters and lessons in real-time as users type
- Displays only matching results (case-insensitive)
- Shows a "no results" message when no matches are found
- Maintains correct chapter numbering and completion status

**Implementation:**
- Created `app/utils/hooks.ts` with `useSearch` custom hook for search logic
- Updated `OutlineDrawer` component to include search input and filtered results
- Added comprehensive comments explaining the code per maintainer feedback

**Does this PR introduce a breaking change?**

No