### PR TITLE
Add beautify btn to format the code

### DIFF
--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -97,12 +97,14 @@ const useCodePersistence = (
 // EditorControls component for the buttons section
 const EditorControls = ({
   handleValidate,
+  handleBeautify,
   isValidating,
   resetCode,
   nextStepPath,
   outputResult,
 }: {
   handleValidate: () => void;
+  handleBeautify: () => void;
   isValidating: boolean;
   resetCode: () => void;
   nextStepPath: string | undefined;
@@ -125,6 +127,10 @@ const EditorControls = ({
 
         <MyBtn onClick={resetCode} variant="error">
           Reset
+        </MyBtn>
+
+        <MyBtn onClick={handleBeautify} variant="secondary">
+          Beautify
         </MyBtn>
       </Flex>
       {!nextStepPath ? (
@@ -208,6 +214,8 @@ export default function CodeEditor({
     dispatchOutput({ type: "RESET" });
   };
 
+  const handleBeautify = () => tryFormattingCode(editorRef, setCodeString);
+
   const handleEditorMount = (editor: any, monaco: Monaco) => {
     setMonaco(monaco);
 
@@ -237,6 +245,7 @@ export default function CodeEditor({
       </div>
       <EditorControls
         handleValidate={handleValidate}
+        handleBeautify={handleBeautify}
         isValidating={isValidating}
         resetCode={resetCode}
         nextStepPath={nextStepPath}

--- a/app/components/MyBtn/MyBtn.tsx
+++ b/app/components/MyBtn/MyBtn.tsx
@@ -10,7 +10,7 @@ export default function MyBtn({
   size = "xs",
 }: {
   children: React.ReactNode;
-  variant: "success" | "error" | "default";
+  variant: "success" | "error" | "default" | "secondary";
   onClick: () => void;
   isDisabled?: boolean;
   tooltip?: string;

--- a/app/styles/theme.ts
+++ b/app/styles/theme.ts
@@ -15,6 +15,19 @@ const Button = {
         bg: "hsl(var(--primary) / 0.6)",
       },
     },
+    secondary: {
+      color: "hsl(var(--text))",
+      bg: "hsl(var(--background2))",
+      borderColor: "hsl(var(--border-color))",
+      borderWidth: "1px",
+      _hover: {
+        bg: "hsl(var(--primary) / 0.12)",
+        borderColor: "hsl(var(--primary))",
+      },
+      _active: {
+        bg: "hsl(var(--primary) / 0.2)",
+      },
+    },
     success: {
       color: "hsl(var(--success))",
       borderColor: "hsl(var(--success))",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This pr includes an extra editor button which formats the code which can help anyone understand what they have updated, specifially when we talk about nestedObjects, arrayOfObjects

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Others? 
- this was small enhancement I dont think we need to make issue for that, but if its necessary we can have one 

**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/447e2e33-3a21-4a8b-a129-f5da4eb6f2b9" />

**If relevant, did you update the documentation?**
Not required

<!--Add link to it-->

**Summary**
I am a fan of how postman let user format there json before hitting the endpoints, it helps user to have crystal clarity on what kind json they are working on, I feel we need to have something similar in tour

I always tend to do formatting before validating this helps me to understand what I have updated, but currently we only have option to validate which then formats the code
<img width="982" height="401" alt="image" src="https://github.com/user-attachments/assets/c3a9fef6-f57f-4911-adef-6731325a0a53" />

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->