### PR TITLE
issue #167: added missing test case in chapter 5 lesson 2

### DIFF
--- a/content/05-Conditional-Validation/02-Ensuring-Mutual-Dependency/code.ts
+++ b/content/05-Conditional-Validation/02-Ensuring-Mutual-Dependency/code.ts
@@ -59,6 +59,12 @@ const testCases = [
     },
     expected: false,
   },
+  {
+    input: {
+      name: "John Doe",
+    },
+    expected: true,
+  },
 ];
 
 module.exports = {


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
It simply adds a test case in the Mutual Dependency lesson
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #167 

**Summary**
The “Mutual Dependency” lesson in Tour of JSON Schema lacked a proper test case to illustrate the difference between a mutual-dependency schema and one that simply uses the required keyword
Because of that, a schema could pass the lesson even though it should have failed or behaved differently under “mutual dependency” rules

I solved this issue by adding the following test case to the lesson
```json
{
  "name": "John Doe"
}
```